### PR TITLE
Adding transform CONSECTIVEABOVE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs/
 nbactions.xml
 nb-configuration.xml
 argus-build.properties
+.DS_Store

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveAboveValueMapping.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveAboveValueMapping.java
@@ -96,36 +96,4 @@ public class ConsectiveAboveValueMapping implements ValueMapping{
 		return TransformFactory.Function.CONSECTIVEABOVE.name();
 	}
 }
-
-
-//Another implementation. Much more efficent but this stacks up in memory, so please don't use this one.
-//private Map<Long, String> originalDatapoints;
-//private ArrayList<Long> keyList;
-//private Map<Long, String> resultMetric = new TreeMap<Long, String>();
-//private int threshold=0;
-//private int consective=0;
-//
-//private Object crawler(int i,int cum){
-//	if(i==keyList.size()){	
-//		if(cum>=consective){
-//			for(long j:keyList.subList(i-cum, i)){
-//				System.out.println(j);
-//			}
-//		}
-//		return null;
-//	}
-//	Double value=Double.parseDouble(originalDatapoints.get(keyList.get(i)));
-//	System.out.println("currently-"+value);
-//	if (value>=threshold){//collect you
-//		return crawler(i+1,cum+1);
-//	}else{//not collecting
-//		if(cum>=consective){
-//			for(long j:keyList.subList(i-cum, i)){
-//				System.out.println(j);
-//			}
-//		}
-//		return crawler(i+1,0);
-//	}
-//}
-
 /* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveAboveValueMapping.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveAboveValueMapping.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2016, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dva.argus.service.metric.transform;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import com.salesforce.dva.argus.system.SystemAssert;
+
+/**
+ * Given a time series, capture the data points meets the requirement below, to form a new time series.
+ * This class captures all the data points whose value is above threshold1, and continuesely for threshold2 consective data points.
+ *
+ * @author  Ethan Wang (ethan.wang@salesforce.com)
+ */
+public class ConsectiveAboveValueMapping implements ValueMapping{
+ 
+	@Override
+	public Map<Long, String> mapping(Map<Long, String> originalDatapoints, List<String> constants) {
+		SystemAssert.requireArgument(constants != null && !constants.equals(""), "Thresholds must be provided!");
+		SystemAssert.requireArgument(constants.size()==2, "Please put in two parameter. Threshold and consective threshold");
+		
+		
+		Double threshold=Double.valueOf(constants.get(0));
+		Integer consective=Integer.valueOf(constants.get(1));
+		SystemAssert.requireArgument(consective!=0, "Consective threshold can not be zero");
+		
+		
+		Map<Long, String> resultMetric = new TreeMap<Long, String>();
+		ArrayList<Long> keyList=new ArrayList<Long>();
+		keyList.addAll(originalDatapoints.keySet());
+		Collections.sort(keyList);
+	
+		int cum=0;
+		for(int i=0;i<keyList.size();i++){
+			Double value=Double.parseDouble(originalDatapoints.get(keyList.get(i)));
+			if (i==keyList.size()-1){
+				if(value>=threshold){cum+=1;i++;}
+				if(cum>=consective){
+					for(int j=i-1;j>(i-1-cum);j--){
+						resultMetric.put(keyList.get(j), String.valueOf(originalDatapoints.get(keyList.get(j))));
+					}
+				}
+				continue;
+			}
+			if (value>=threshold){
+				cum+=1;
+			}else{
+				if(cum>=consective){
+					for(int j=i-1;j>(i-1-cum);j--){
+						resultMetric.put(keyList.get(j), String.valueOf(originalDatapoints.get(keyList.get(j))));
+					}
+				}
+				cum=0;
+			}
+		}
+		return resultMetric;
+	}
+	
+	@Override
+	public Map<Long, String> mapping(Map<Long, String> originalDatapoints) {
+		throw new UnsupportedOperationException("This transform does requires an input!");
+	}
+
+	@Override
+	public String name() {
+		return TransformFactory.Function.CONSECTIVEABOVE.name();
+	}
+}
+
+
+//Another implementation. Much more efficent but this stacks up in memory, so please don't use this one.
+//private Map<Long, String> originalDatapoints;
+//private ArrayList<Long> keyList;
+//private Map<Long, String> resultMetric = new TreeMap<Long, String>();
+//private int threshold=0;
+//private int consective=0;
+//
+//private Object crawler(int i,int cum){
+//	if(i==keyList.size()){	
+//		if(cum>=consective){
+//			for(long j:keyList.subList(i-cum, i)){
+//				System.out.println(j);
+//			}
+//		}
+//		return null;
+//	}
+//	Double value=Double.parseDouble(originalDatapoints.get(keyList.get(i)));
+//	System.out.println("currently-"+value);
+//	if (value>=threshold){//collect you
+//		return crawler(i+1,cum+1);
+//	}else{//not collecting
+//		if(cum>=consective){
+//			for(long j:keyList.subList(i-cum, i)){
+//				System.out.println(j);
+//			}
+//		}
+//		return crawler(i+1,0);
+//	}
+//}
+
+/* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/TransformFactory.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/TransformFactory.java
@@ -160,6 +160,8 @@ public class TransformFactory {
                 return new MetricMappingTransform(new ShiftValueMapping());
             case MOVING:
                 return new MetricMappingTransform(new MovingValueMapping());
+            case CONSECTIVEABOVE:
+            	return new MetricMappingTransform(new ConsectiveAboveValueMapping());
             case SUM_V:
                 return new MetricZipperTransform(new SumValueZipper());
             case SCALE_V:
@@ -238,7 +240,8 @@ public class TransformFactory {
         EXCLUDE("EXCLUDE", "Culls metrics based on the matching of a regular expression against the metric name."),
         HW_FORECAST("HW_FORECAST", "Performns HoltWinters Forecast."),
         HW_DEVIATION("HW_DEVIATION", "Performns HoltWinters Deviation."),
-        GROUPBY("GROUPBY", "Creates groups of metrics based on some matching criteria and then performs the given aggregation.");
+        GROUPBY("GROUPBY", "Creates groups of metrics based on some matching criteria and then performs the given aggregation."),
+        CONSECTIVEABOVE("CONSECTIVEABOVE","this is just for test use");
 
         private final String _name;
         private final String _description;

--- a/ArgusCore/src/main/javacc/MetricReader.jj
+++ b/ArgusCore/src/main/javacc/MetricReader.jj
@@ -1,3 +1,5 @@
+
+
 options {
 STATIC = false;
 LOOKAHEAD = 1;
@@ -379,9 +381,9 @@ private String functionName() :
 	t = <ABOVE>
 	{ return t.image; }
 	|
-	t = <CONSECTIVEABOVE>
-	{ return t.image; }
-	|    
+    t = <CONSECTIVEABOVE>
+    { return t.image; }
+    |
 	t = <BELOW>
 	{ return t.image; }
 	|	
@@ -445,8 +447,7 @@ private List<T> evaluateFunction(String functionName, List<T> result, List<Strin
 {
   	{
   	  	if(MetricQuery.class.equals(clazz)) {
-  	  		return (List<T>) result;
-  	  	} else if(Metric.class.equals(clazz)) {
+  	  		return (List<T>) result;  	  	} else if(Metric.class.equals(clazz)) {
   	  	  	if(syntaxOnly) {
 				return (List<T>) Arrays.asList( new Metric[] { new Metric("test","metric") });
 	  	  	} else {
@@ -455,8 +456,7 @@ private List<T> evaluateFunction(String functionName, List<T> result, List<Strin
 				return (List<T>) ((constants == null || constants.isEmpty()) ? transform.transform((List<Metric>) result) : transform.transform((List<Metric>) result, constants));
 	  	  	}
 	  	} else {
-	  	  	throw new IllegalArgumentException("Invalid class type: " + clazz);
-	  	}
+	  	  	throw new IllegalArgumentException("Invalid class type: " + clazz);	  	}
 	}
 }
 
@@ -493,9 +493,7 @@ private List<T> expression(long offsetInMillis, boolean syntaxOnly, Class<T> cla
 	        query.setDownsampler(downsampler);
 	        query.setDownsamplingPeriod(downsamplingPeriod);
 	        List<MetricQuery> queries = discoveryService.getMatchingQueries(query);
-	        return (List<T>) queries;
-	  	} else if(Metric.class.equals(clazz)) {
-			if(syntaxOnly) {
+	        return (List<T>) queries;	  	} else if(Metric.class.equals(clazz)) {			if(syntaxOnly) {
 	            return (List<T>) Arrays.asList( new Metric[] { new Metric("test","metric") });
 	        } else {
 	          	downsampler = downsampleTokenStr != null ? getDownsampler(downsampleTokenStr) : null;
@@ -515,8 +513,7 @@ private List<T> expression(long offsetInMillis, boolean syntaxOnly, Class<T> cla
 	            }
 	            return (List<T>) metrics;
 	        }
-	  	} else {
-			throw new IllegalArgumentException("Invalid class type: " + clazz);
+	  	} else {			throw new IllegalArgumentException("Invalid class type: " + clazz);
 	  	}
 	}
 }

--- a/ArgusCore/src/main/javacc/MetricReader.jj
+++ b/ArgusCore/src/main/javacc/MetricReader.jj
@@ -165,6 +165,7 @@ TOKEN : { < UNION : "UNION" > }
 TOKEN : { < COUNT : "COUNT" > }
 TOKEN : { < GROUP : "GROUP" > }
 TOKEN : { < ABOVE : "ABOVE" > }
+TOKEN : { < CONSECTIVEABOVE : "CONSECTIVEABOVE" > }
 TOKEN : { < BELOW : "BELOW" > }
 TOKEN : { < PROPAGATE : "PROPAGATE" > }
 TOKEN : { < MOVING : "MOVING" > }
@@ -378,6 +379,9 @@ private String functionName() :
 	t = <ABOVE>
 	{ return t.image; }
 	|	
+    t = <CONSECTIVEABOVE>
+    { return t.image; }
+    |    
 	t = <BELOW>
 	{ return t.image; }
 	|	

--- a/ArgusCore/src/main/javacc/MetricReader.jj
+++ b/ArgusCore/src/main/javacc/MetricReader.jj
@@ -378,10 +378,10 @@ private String functionName() :
 	|
 	t = <ABOVE>
 	{ return t.image; }
-	|	
-    t = <CONSECTIVEABOVE>
-    { return t.image; }
-    |    
+	|
+	t = <CONSECTIVEABOVE>
+	{ return t.image; }
+	|    
 	t = <BELOW>
 	{ return t.image; }
 	|	
@@ -445,7 +445,8 @@ private List<T> evaluateFunction(String functionName, List<T> result, List<Strin
 {
   	{
   	  	if(MetricQuery.class.equals(clazz)) {
-  	  		return (List<T>) result;  	  	} else if(Metric.class.equals(clazz)) {
+  	  		return (List<T>) result;
+  	  	} else if(Metric.class.equals(clazz)) {
   	  	  	if(syntaxOnly) {
 				return (List<T>) Arrays.asList( new Metric[] { new Metric("test","metric") });
 	  	  	} else {
@@ -454,7 +455,8 @@ private List<T> evaluateFunction(String functionName, List<T> result, List<Strin
 				return (List<T>) ((constants == null || constants.isEmpty()) ? transform.transform((List<Metric>) result) : transform.transform((List<Metric>) result, constants));
 	  	  	}
 	  	} else {
-	  	  	throw new IllegalArgumentException("Invalid class type: " + clazz);	  	}
+	  	  	throw new IllegalArgumentException("Invalid class type: " + clazz);
+	  	}
 	}
 }
 
@@ -491,7 +493,9 @@ private List<T> expression(long offsetInMillis, boolean syntaxOnly, Class<T> cla
 	        query.setDownsampler(downsampler);
 	        query.setDownsamplingPeriod(downsamplingPeriod);
 	        List<MetricQuery> queries = discoveryService.getMatchingQueries(query);
-	        return (List<T>) queries;	  	} else if(Metric.class.equals(clazz)) {			if(syntaxOnly) {
+	        return (List<T>) queries;
+	  	} else if(Metric.class.equals(clazz)) {
+			if(syntaxOnly) {
 	            return (List<T>) Arrays.asList( new Metric[] { new Metric("test","metric") });
 	        } else {
 	          	downsampler = downsampleTokenStr != null ? getDownsampler(downsampleTokenStr) : null;
@@ -511,7 +515,8 @@ private List<T> expression(long offsetInMillis, boolean syntaxOnly, Class<T> cla
 	            }
 	            return (List<T>) metrics;
 	        }
-	  	} else {			throw new IllegalArgumentException("Invalid class type: " + clazz);
+	  	} else {
+			throw new IllegalArgumentException("Invalid class type: " + clazz);
 	  	}
 	}
 }

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/AbstractTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/AbstractTest.java
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright (c) 2016, Salesforce.com, Inc.
  * All rights reserved.
  *

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveAboveValueMappingTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveAboveValueMappingTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2016, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dva.argus.service.metric.transform;
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import com.salesforce.dva.argus.entity.Metric;
+
+public class ConsectiveAboveValueMappingTest {
+	private static final String TEST_SCOPE = "test-scope";
+    private static final String TEST_METRIC = "test-metric";
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testShiftTransformWithoutMetrics() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        List<Metric> metrics = null;
+        List<String> constants = new ArrayList<String>();
+
+        constants.add("1");
+        constants.add("2");
+        transform.transform(metrics, constants);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testShiftTransformWithoutThreshold() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        transform.transform(metrics, constants);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testShiftTransformWithOnlyOneThreshold() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("1");
+        transform.transform(metrics, constants);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testShiftTransformWithZeroConsectiveThreshold() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("1");
+        constants.add("0");
+        transform.transform(metrics, constants);
+    }
+    
+    @Test
+    public void testConsectiveAboveValueMappingSingleBaseCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+
+        datapoints_1.put(1000L, "3.0");
+        datapoints_1.put(2000L, "0.0");
+        datapoints_1.put(3000L, "3.0");
+        datapoints_1.put(4000L, "5.0");
+        datapoints_1.put(5000L, "3.0");
+        datapoints_1.put(6000L, "1.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("3");
+        constants.add("2");
+        
+        Map<Long, String> expected = new HashMap<Long, String>();
+        expected.put(3000L, "3.0");
+        expected.put(4000L, "5.0");
+        expected.put(5000L, "3.0");
+        
+        List<Metric> result = transform.transform(metrics,constants);
+        assertEquals("For single metric, base cases, result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("For single metric, base cases, result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveAboveValueMappingSingleEdgeCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+
+        datapoints_1.put(1000L, "3.0");
+        datapoints_1.put(2000L, "0.0");
+        datapoints_1.put(3000L, "3.0");
+        datapoints_1.put(4000L, "5.0");
+        datapoints_1.put(5000L, "3.0");
+        datapoints_1.put(6000L, "9.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("2.95");
+        constants.add("1");
+       
+        Map<Long, String> expected = new HashMap<Long, String>();
+        expected.put(1000L, "3.0");
+        expected.put(3000L, "3.0");
+        expected.put(4000L, "5.0");
+        expected.put(5000L, "3.0");
+        expected.put(6000L, "9.0");
+        
+        List<Metric> result = transform.transform(metrics,constants);
+        assertEquals("For single metric, edge cases(Float, first, last match), result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("For single metric, edge cases(Float, first, last match), result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveAboveValueMappingSingleZeroCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        datapoints_1.put(1000L, "-20.0");
+        datapoints_1.put(2000L, "0.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("0");
+        constants.add("10");
+       
+        Map<Long, String> expected = new HashMap<Long, String>();
+        
+        List<Metric> result = transform.transform(metrics,constants);
+        assertEquals("For single metric, zero cases, result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("For single metric, zero cases, result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveAboveValueMappingSingleSerilesMissingDatasCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        datapoints_1.put(1000L, "-20.0");
+        datapoints_1.put(2000L, "0.0");
+        datapoints_1.put(6000L, "4.0");
+        datapoints_1.put(11000L, "5.0");
+
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("2");
+        constants.add("2");
+       
+        Map<Long, String> expected = new HashMap<Long, String>();
+        expected.put(6000L, "4.0");
+        expected.put(11000L, "5.0");
+        
+        List<Metric> result = transform.transform(metrics,constants);
+        assertEquals("For single metric, when metric missing data, should detect neigbour data points as consective points. result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("For single metric, when metric missing data, should detect neigbour data points as consective points. result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    
+    @Test
+    public void testConsectiveAboveValueMappingMultipleCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveAboveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        datapoints_1.put(1000L, "3.0");
+        datapoints_1.put(2000L, "0.0");
+        datapoints_1.put(3000L, "3.0");
+        datapoints_1.put(4000L, "5.0");
+        datapoints_1.put(5000L, "3.0");
+        datapoints_1.put(6000L, "1.0");
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+               
+        Map<Long, String> datapoints_2 = new HashMap<Long, String>();
+        datapoints_2.put(1000L, "3.0");
+        datapoints_2.put(2000L, "12.0");
+        datapoints_2.put(3000L, "0.0");
+        Metric metric_2 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_2.setDatapoints(datapoints_2);
+        
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        metrics.add(metric_2);
+
+        List<String> constants = new ArrayList<String>();
+        constants.add("2.5");
+        constants.add("2");
+        
+        Map<Long, String> expected_1 = new HashMap<Long, String>();
+        expected_1.put(3000L, "3.0");
+        expected_1.put(4000L, "5.0");
+        expected_1.put(5000L, "3.0");
+        Map<Long, String> expected_2 = new HashMap<Long, String>();
+        expected_2.put(1000L, "3.0");
+        expected_2.put(2000L, "12.0");
+        
+        List<Metric> result = transform.transform(metrics,constants);
+        assertEquals("For mulitple metric, the first seriles, result length should match",result.get(0).getDatapoints().size(), expected_1.size());
+        assertEquals("For mulitple metric, the first seriles, result value should match",expected_1, result.get(0).getDatapoints());
+        assertEquals("For mulitple metric, the second seriles, result length should match",result.get(1).getDatapoints().size(), expected_2.size());
+        assertEquals("For mulitple metric, the second seriles, result value should match",expected_2, result.get(1).getDatapoints());
+    }
+
+}
+
+/* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusCore/src/test/resources/com/salesforce/dva/argus/service/metric/MetricReaderTest.testFunctionsWithConstant.properties
+++ b/ArgusCore/src/test/resources/com/salesforce/dva/argus/service/metric/MetricReaderTest.testFunctionsWithConstant.properties
@@ -135,3 +135,8 @@ fun-relative-timestamps-without-endTs-exclude=EXCLUDE(-20h:na1:app_record.count{
 fun-startTs-absolute-endTs-relative-exclude=EXCLUDE(123000:-1m:na1:app_record.count{tagk=tagv}:avg:15m-avg,123000:234000:na1:app_record.count{tak=tagv}:avg, $null)
 fun-all-fields-wildcardtags1-exclude=EXCLUDE(123000:234000:na1:app_record.count{tagk=*}:avg:15m-avg, $10)
 fun-all-fields-wildcardtags2-exclude=EXCLUDE(123000:234000:na1:app_record.count{tagk=tagv1|tagv2}:avg:15m-avg, $10)
+
+fun-relative-timestamps-without-endTs-consectiveasbove=CONSECTIVEABOVE(-20h:na1:app_record.count{tagk=tagv}:avg:15m-avg,123000:234000:na1:app_record.count{tak=tagv}:avg, $10,$10)
+fun-startTs-absolute-endTs-relative-consectiveasbove=CONSECTIVEABOVE(123000:-1m:na1:app_record.count{tagk=tagv}:avg:15m-avg,123000:234000:na1:app_record.count{tak=tagv}:avg, $10,$10)
+fun-all-fields-wildcardtags1-consectiveasbove=CONSECTIVEABOVE(123000:234000:na1:app_record.count{tagk=*}:avg:15m-avg, $10,$10)
+fun-all-fields-wildcardtags2-consectiveasbove=CONSECTIVEABOVE(123000:234000:na1:app_record.count{tagk=tagv1|tagv2}:avg:15m-avg, $10,$10)


### PR DESCRIPTION
Adding transform CONSECTIVEABOVE.

Given a time series, capture the data points meets the requirement below, to form a new time series.
This transform captures all the data points whose value is above threshold1, and continuesely for threshold2 consective data points.

ethan.wang@salesforce.com