### PR TITLE
CONSECTIVE TRANSFORM ADDED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ logs/
 nbactions.xml
 nb-configuration.xml
 argus-build.properties
+.DS_Store

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveValueMapping.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveValueMapping.java
@@ -56,25 +56,19 @@ public class ConsectiveValueMapping implements ValueMapping {
         SystemAssert.requireArgument(constants.size() == 2, "This transform must provide exactly 2 constants.");    
         this.threshold = getOffsetInSeconds(constants.get(0)) * 1000;
         this.connectDistance = getOffsetInSeconds(constants.get(1)) * 1000;
-        
-        
+              
         Map<Long, String> resultMetric = new TreeMap<Long, String>();
         this.keyList=new ArrayList<Long>();
         this.resultKeyList=new ArrayList<Long>();
 		keyList.addAll(originalDatapoints.keySet());
 		Collections.sort(keyList);
 		
-		System.out.println("THIS RUN!");
 		if (keyList.size()>0){
 			connect(0,new ArrayList<>(Arrays.asList(keyList.get(0))));
 		}
-		System.out.println(originalDatapoints);
-		System.out.println(this.resultKeyList);
 		for(Long resultKey:resultKeyList){
 			resultMetric.put(resultKey, originalDatapoints.get(resultKey));
 		}
-		
-		System.out.println(resultMetric);
 		return resultMetric;
 	}
 	

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveValueMapping.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveValueMapping.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2016, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dva.argus.service.metric.transform;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import com.salesforce.dva.argus.service.metric.MetricReader;
+import com.salesforce.dva.argus.system.SystemAssert;
+
+/**
+ * CONSECUTIVE: Returns all datapoint's for which the interval between adjacent datapoints is less than or equal to the specified time interval, for consective specified time threshold .
+ *
+ * @author  Ethan Wang (ethan.wang@salesforce.com)
+ */
+public class ConsectiveValueMapping implements ValueMapping {
+	private long threshold;
+	private long connectDistance;
+	private ArrayList<Long> keyList;
+	private ArrayList<Long> resultKeyList;
+	
+	@Override
+	public Map<Long, String> mapping(Map<Long, String> originalDatapoints, List<String> constants) {
+		SystemAssert.requireArgument(constants != null, "This transform needs constants");
+        SystemAssert.requireArgument(constants.size() == 2, "This transform must provide exactly 2 constants.");    
+        this.threshold = getOffsetInSeconds(constants.get(0)) * 1000;
+        this.connectDistance = getOffsetInSeconds(constants.get(1)) * 1000;
+        
+        
+        Map<Long, String> resultMetric = new TreeMap<Long, String>();
+        this.keyList=new ArrayList<Long>();
+        this.resultKeyList=new ArrayList<Long>();
+		keyList.addAll(originalDatapoints.keySet());
+		Collections.sort(keyList);
+		
+		System.out.println("THIS RUN!");
+		if (keyList.size()>0){
+			connect(0,new ArrayList<>(Arrays.asList(keyList.get(0))));
+		}
+		System.out.println(originalDatapoints);
+		System.out.println(this.resultKeyList);
+		for(Long resultKey:resultKeyList){
+			resultMetric.put(resultKey, originalDatapoints.get(resultKey));
+		}
+		
+		System.out.println(resultMetric);
+		return resultMetric;
+	}
+	
+	private Object connect(int current,ArrayList<Long> carryList){		
+		if (current+2==keyList.size()){
+			if (keyList.get(current+1)-keyList.get(current)<=connectDistance){
+				carryList.add(keyList.get(current+1));
+			}
+			if (carryList.size()>0 && Collections.max(carryList)-Collections.min(carryList)>=threshold){
+				resultKeyList.addAll(carryList);
+			}
+			return null;
+		}
+		if (keyList.get(current+1)-keyList.get(current)<=connectDistance){
+			carryList.add(keyList.get(current+1));
+			return connect(current+1,carryList);
+		}
+		if (carryList.size()>0 && Collections.max(carryList)-Collections.min(carryList)>=threshold){
+			resultKeyList.addAll(carryList);
+		}
+		return connect(current+1,new ArrayList<>(Arrays.asList(keyList.get(current+1)))); 
+	}
+	
+	private long getOffsetInSeconds(String offset) {
+        MetricReader.TimeUnit timeunit = null;
+        Long backwards = 1L;
+        try {
+            if (offset.startsWith("-")) {
+                backwards = -1L;
+                offset = offset.substring(1);
+            }
+            if (offset.startsWith("+")) {
+                offset = offset.substring(1);
+            }
+            timeunit = MetricReader.TimeUnit.fromString(offset.substring(offset.length() - 1));
+            long timeDigits = Long.parseLong(offset.substring(0, offset.length() - 1));
+            return backwards * timeDigits * timeunit.getValue() / 1000;
+        } catch (Exception t) {
+            throw new IllegalArgumentException("Fail to parse offset!");
+        }
+    }
+
+	@Override
+	public Map<Long, String> mapping(Map<Long, String> originalDatapoints) {
+		throw new UnsupportedOperationException("Consective Transform needs a threshold and type.");
+	}
+	
+	@Override
+	public String name() {
+		return TransformFactory.Function.CONSECTIVE.name();
+	}
+}
+/* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/TransformFactory.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/TransformFactory.java
@@ -154,6 +154,8 @@ public class TransformFactory {
                 return new MetricMappingTransform(new CullAboveValueMapping());
             case CULL_BELOW:
                 return new MetricMappingTransform(new CullBelowValueMapping());
+            case CONSECTIVE:
+            	return new MetricMappingTransform(new ConsectiveValueMapping());
             case LOG:
                 return new MetricMappingTransform(new LogValueMapping());
             case SHIFT:
@@ -221,6 +223,7 @@ public class TransformFactory {
         DOWNSAMPLE("DOWNSAMPLE", "Down samples the one or more metric."),
         CULL_ABOVE("CULL_ABOVE", "Removes data points from metrics if their evaluated value is above a limit. "),
         CULL_BELOW("CULL_BELOW", "Removes data points from metrics if their evaluated value is below a limit. "),
+        CONSECTIVE("CONSECTIVE","Filter out all values that is not consective"),
         SHIFT("SHIFT", "Shifts the timestamp for each data point by the specified constant."),
         LOG("LOG", "Calculates the logarithm according to the specified base."),
         JOIN("JOIN", "Joins multiple lists of metrics into a single list."),

--- a/ArgusCore/src/main/javacc/MetricReader.jj
+++ b/ArgusCore/src/main/javacc/MetricReader.jj
@@ -179,6 +179,7 @@ TOKEN : { < FILL_CALCULATE : "FILL_CALCULATE" > }
 TOKEN : { < LOG : "LOG" > }
 TOKEN : { < CULL_ABOVE : "CULL_ABOVE" > }
 TOKEN : { < CULL_BELOW : "CULL_BELOW" > }
+TOKEN : { < CONSECTIVEABOVE : "CONSECTIVEABOVE" > }
 TOKEN : { < SORT : "SORT" > }
 TOKEN : { < SHIFT : "SHIFT" > }
 TOKEN : { < DOWNSAMPLE : "DOWNSAMPLE" > }
@@ -412,6 +413,9 @@ private String functionName() :
 	{ return t.image; }
 	|	
 	t = <CULL_BELOW>
+	{ return t.image; }
+	|
+	t = <CONSECTIVE>
 	{ return t.image; }
 	|	
 	t = <SORT>

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveValueMappingTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/ConsectiveValueMappingTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2016, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.salesforce.dva.argus.service.metric.transform;
+import static org.junit.Assert.assertEquals;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.junit.Test;
+import com.salesforce.dva.argus.entity.Metric;
+
+public class ConsectiveValueMappingTest {
+	private static final String TEST_SCOPE = "test-scope";
+    private static final String TEST_METRIC = "test-metric";
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testConsectiveTransformWithoutMetrics() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        List<Metric> metrics = null;
+        List<String> constants = new ArrayList<String>();
+
+        constants.add("1s");
+        constants.add("2s");
+        transform.transform(metrics, constants);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testConsectiveTransformWithoutThreshold() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        transform.transform(metrics, constants);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testConsectiveTransformWithOnlyOneThreshold() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("1s");
+        transform.transform(metrics, constants);
+    }
+    
+    @Test(expected = IllegalArgumentException.class)
+    public void testConsectiveTransformWithZeroConsectiveThreshold() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("0");
+        constants.add("0");
+        transform.transform(metrics, constants);
+    }
+    
+    @Test
+    public void testConsectiveValueMappingSingleBaseCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+
+        datapoints_1.put(1000L, "0.0");
+        datapoints_1.put(3000L, "1.0");
+        datapoints_1.put(4000L, "1.0");
+        datapoints_1.put(5000L, "1.0");
+        datapoints_1.put(7000L, "1.0");
+        datapoints_1.put(8000L, "1.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("1s");
+        constants.add("1s");
+        
+        Map<Long, String> expected = new HashMap<Long, String>();
+        expected.put(3000L, "1.0");
+        expected.put(4000L, "1.0");
+        expected.put(5000L, "1.0");
+        expected.put(7000L, "1.0");
+        expected.put(8000L, "1.0");
+        List<Metric> result = transform.transform(metrics,constants);
+
+        assertEquals("Result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("Result value should match",expected, result.get(0).getDatapoints());
+    }
+
+    @Test
+    public void testConsectiveValueMappingSingleEdgeCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+
+        datapoints_1.put(1000L, "0.0");
+        datapoints_1.put(3000L, "1.0");
+        datapoints_1.put(5000L, "1.0");
+        datapoints_1.put(6000L, "1.0");
+        datapoints_1.put(7000L, "1.0");
+        datapoints_1.put(8000L, "1.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("3s");
+        constants.add("1s");
+        
+        Map<Long, String> expected = new HashMap<Long, String>();
+        expected.put(5000L, "1.0");
+        expected.put(6000L, "1.0");
+        expected.put(7000L, "1.0");
+        expected.put(8000L, "1.0");
+        List<Metric> result = transform.transform(metrics,constants);
+
+        assertEquals("Result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("Result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveValueMappingSingleIntervalCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+
+        datapoints_1.put(1000000L, "0.0");
+        datapoints_1.put(3000000L, "1.0");
+        datapoints_1.put(5000000L, "1.0");
+        datapoints_1.put(5500000L, "1.0");
+        datapoints_1.put(6000000L, "1.0");
+        datapoints_1.put(9000000L, "1.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("10m");
+        constants.add("10m");
+        
+        Map<Long, String> expected = new HashMap<Long, String>();
+        expected.put(5000000L, "1.0");
+        expected.put(5500000L, "1.0");
+        expected.put(6000000L, "1.0");
+        List<Metric> result = transform.transform(metrics,constants);
+
+        assertEquals("Result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("Result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveValueMappingSingleZeroCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+
+        datapoints_1.put(1000L, "0.0");
+        datapoints_1.put(2000L, "1.0");
+        datapoints_1.put(3000L, "1.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("4s");
+        constants.add("1s");
+        
+        Map<Long, String> expected = new HashMap<Long, String>();
+        List<Metric> result = transform.transform(metrics,constants);
+
+        assertEquals("Result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("Result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveValueMappingEmptySeriesCases() {
+        Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("4s");
+        constants.add("1s");
+        
+        Map<Long, String> expected = new HashMap<Long, String>();
+        List<Metric> result = transform.transform(metrics,constants);
+
+        assertEquals("Result length should match",result.get(0).getDatapoints().size(), expected.size());
+        assertEquals("Result value should match",expected, result.get(0).getDatapoints());
+    }
+    
+    @Test
+    public void testConsectiveValueMappingMultipleSeriesCases() {
+    	Transform transform = new MetricMappingTransform(new ConsectiveValueMapping());
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        datapoints_1.put(1000L, "0.0");
+        datapoints_1.put(3000L, "1.0");
+        datapoints_1.put(5000L, "1.0");
+        datapoints_1.put(6000L, "1.0");
+        datapoints_1.put(7000L, "1.0");
+        
+        Map<Long, String> datapoints_2 = new HashMap<Long, String>();
+        datapoints_2.put(4000L, "0.0");
+        datapoints_2.put(5000L, "1.0");
+        datapoints_2.put(6000L, "1.0");
+        datapoints_2.put(11000L, "1.0");
+
+        Metric metric_1 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        Metric metric_2 = new Metric(TEST_SCOPE, TEST_METRIC);
+        metric_2.setDatapoints(datapoints_2);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+        metrics.add(metric_2);
+        
+        List<String> constants = new ArrayList<String>();
+        constants.add("2s");
+        constants.add("1s");
+        Map<Long, String> expected_1 = new TreeMap<Long, String>();
+        expected_1.put(5000L, "1.0");
+        expected_1.put(6000L, "1.0");
+        expected_1.put(7000L, "1.0");
+        
+        Map<Long, String> expected_2 = new TreeMap<Long, String>();
+        expected_2.put(4000L, "0.0");
+        expected_2.put(5000L, "1.0");
+        expected_2.put(6000L, "1.0");
+        List<Metric> result = transform.transform(metrics,constants);
+        assertEquals("Result length should match",result.get(0).getDatapoints().size(), expected_1.size());
+        assertEquals("Result value should match",expected_1, result.get(0).getDatapoints());
+        assertEquals("Result length should match",result.get(1).getDatapoints().size(), expected_2.size());
+        assertEquals("Result value should match",expected_2, result.get(1).getDatapoints());
+    }
+}
+/* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */


### PR DESCRIPTION
CONSECUTIVE: Returns all datapoint's for which the interval between adjacent datapoints is less than or equal to the specified time interval, for consective specified time threshold 

USAGE: CONSECTIVE(-1h:argus.jvm:mem.heap.used:avg,$5m,$1m)