### PR TITLE
fixed a bug that was originally in Downsample transform

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/DownsampleTransform.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/metric/transform/DownsampleTransform.java
@@ -156,6 +156,9 @@ public class DownsampleTransform implements Transform {
         Map<Long, String> downsampleDatapoints = new HashMap<Long, String>();
         TreeMap<Long, String> sortedDatapoints = new TreeMap<Long, String>(originalDatapoints);
         List<String> values = new ArrayList<>();
+        if (sortedDatapoints.isEmpty()){
+        	return downsampleDatapoints;
+        }
         Long windowStart = downsamplerTimestamp(sortedDatapoints.firstKey(),windowSize);
 
         for (Map.Entry<Long, String> entry : sortedDatapoints.entrySet()) {

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/DownsampleTransformTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/DownsampleTransformTest.java
@@ -697,5 +697,24 @@ public class DownsampleTransformTest {
         assertEquals(result.size(), 1);
         assertEquals(expected_1, result.get(0).getDatapoints());
     }
+    
+    @Test
+    public void testDownsampleTransformMetricIsAllNull() {
+    	Transform downsampleTransform = new DownsampleTransform();
+        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        
+        Metric metric_1 = new Metric(TEST_SCOPE + "1", TEST_METRIC);
+        metric_1.setDatapoints(datapoints_1);
+        List<Metric> metrics = new ArrayList<Metric>();
+        metrics.add(metric_1);
+
+        List<String> constants = new ArrayList<String>();
+        constants.add("3s-count");
+        Map<Long, String> expected_1 = new HashMap<Long, String>();
+        List<Metric> result = downsampleTransform.transform(metrics, constants);
+        assertEquals(result.size(), 1);
+        assertEquals(expected_1, result.get(0).getDatapoints());
+    }
+    
 }
 /* Copyright (c) 2016, Salesforce.com, Inc.  All rights reserved. */

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/DownsampleTransformTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/service/metric/transform/DownsampleTransformTest.java
@@ -701,19 +701,19 @@ public class DownsampleTransformTest {
     @Test
     public void testDownsampleTransformMetricIsAllNull() {
     	Transform downsampleTransform = new DownsampleTransform();
-        Map<Long, String> datapoints_1 = new HashMap<Long, String>();
+        Map<Long, String> datapoints = new HashMap<Long, String>();
         
-        Metric metric_1 = new Metric(TEST_SCOPE + "1", TEST_METRIC);
-        metric_1.setDatapoints(datapoints_1);
+        Metric metric = new Metric(TEST_SCOPE + "1", TEST_METRIC);
+        metric.setDatapoints(datapoints);
         List<Metric> metrics = new ArrayList<Metric>();
-        metrics.add(metric_1);
+        metrics.add(metric);
 
         List<String> constants = new ArrayList<String>();
         constants.add("3s-count");
-        Map<Long, String> expected_1 = new HashMap<Long, String>();
+        Map<Long, String> expected = new HashMap<Long, String>();
         List<Metric> result = downsampleTransform.transform(metrics, constants);
         assertEquals(result.size(), 1);
-        assertEquals(expected_1, result.get(0).getDatapoints());
+        assertEquals(expected, result.get(0).getDatapoints());
     }
     
 }


### PR DESCRIPTION
fixed a bug that was originally in Downsample transform.

In this bug, when a metric{tag=*} includes multiple Time series and one of them is empty, DOWNSAMPLE(metric{tag=*},$1h-avg) will raise an exception when calculating window_start. This pull request fixed that bug.