### PR TITLE
Update to remove zookeeper log spew from integration tests.

### DIFF
--- a/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/DefaultTSDBService.java
+++ b/ArgusCore/src/main/java/com/salesforce/dva/argus/service/tsdb/DefaultTSDBService.java
@@ -299,7 +299,7 @@ public class DefaultTSDBService extends DefaultService implements TSDBService {
                 instrumentQueryLatency(_monitorService, entry.getKey(), queryStartExecutionTime.get(entry.getKey()), "metrics");
                 metricsMap.put(entry.getKey(), metrics);
             } catch (InterruptedException | ExecutionException e) {
-                _logger.error("Failed to get metrics from TSDB. Reason: " + e.getMessage());
+                _logger.warn("Failed to get metrics from TSDB. Reason: " + e.getMessage());
                 throw new SystemException("Failed to get metrics from TSDB. Reason: " + e.getMessage());
             }
         }

--- a/ArgusCore/src/test/java/com/salesforce/dva/argus/AbstractTest.java
+++ b/ArgusCore/src/test/java/com/salesforce/dva/argus/AbstractTest.java
@@ -67,6 +67,10 @@ public abstract class AbstractTest {
     static {
         tags = new HashMap<>();
         tags.put("source", "unittest");
+        ch.qos.logback.classic.Logger apacheLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("org.apache");
+        apacheLogger.setLevel(ch.qos.logback.classic.Level.OFF);
+        ch.qos.logback.classic.Logger kafkaLogger = (ch.qos.logback.classic.Logger) LoggerFactory.getLogger("kafka");
+        kafkaLogger.setLevel(ch.qos.logback.classic.Level.OFF);
     }
 
     protected TestingServer zkTestServer;

--- a/ArgusCore/src/test/resources/log4j.properties
+++ b/ArgusCore/src/test/resources/log4j.properties
@@ -1,0 +1,6 @@
+log4j.rootLogger=OFF, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
Make the logging for when a metric isn't found in TSDB to warn as it's normal for this to occur when trying to fetch the UID for an annotation time series upon the first write to it.