### PR TITLE
fix issue of date picker only pick local time. 

### DIFF
--- a/ArgusWeb/app/js/directives/controls/date.js
+++ b/ArgusWeb/app/js/directives/controls/date.js
@@ -29,9 +29,18 @@ angular.module('argus.directives.controls.date', [])
                 '</ul>' +
             '</div>',
         link: function(scope, element, attributes, dashboardCtrl) {
+            //used for process time to GMT format
+            function processGMTTime(timeString){
+                timeStringGMT=timeString+' GMT';
+                dateGMT = Date.parse(timeStringGMT);
+                if(isNaN(dateGMT)){
+                    return timeString;
+                }
+                return dateGMT;
+            };
             dashboardCtrl.updateControl(scope.controlName, scope.controlValue, "agDate");
             scope.$watch('controlValue', function(newValue, oldValue) {
-                dashboardCtrl.updateControl(scope.controlName, newValue, "agDate");
+                dashboardCtrl.updateControl(scope.controlName, processGMTTime(newValue), "agDate");
             });
         }
     }


### PR DESCRIPTION
fix issue of date picker only pick local time.
now it is returning GMT time, which align up with argus.

For the date time that input from URL, or as format as '-5d', it will not convert.